### PR TITLE
added `origin` keyword

### DIFF
--- a/Solidity-PlasticCodeWrap.xml
+++ b/Solidity-PlasticCodeWrap.xml
@@ -30,7 +30,7 @@
             <Keywords name="Keywords4">bool int int8 int16 int32 int64 int128 int256 uint uint8 uint16 uint32 uint64 uint128 uint256 address mapping string struct enum</Keywords>
             <Keywords name="Keywords5">fixed ufixed bytes</Keywords>
             <Keywords name="Keywords6">TODO &quot;TO DO&quot; todo &quot;to do&quot;</Keywords>
-            <Keywords name="Keywords7">Transfer push length gas call delegatecall callcode send transfer balance msg ecrecover keccak256 ripemd160 sha256 sha3 mulmod addmod encodePacked encode encodeWithSelector encodeWithSignature tx block now assert require revert blockhash coinbase difficulty gaslimit number timestamp gasleft data gas sender sig value selfdistruct suicide abi</Keywords>
+            <Keywords name="Keywords7">Transfer push length gas call delegatecall callcode send transfer balance msg ecrecover keccak256 ripemd160 sha256 sha3 mulmod addmod encodePacked encode encodeWithSelector encodeWithSignature tx block now assert require revert blockhash coinbase difficulty gaslimit number timestamp gasleft data gas sender sig value selfdistruct suicide abi origin</Keywords>
             <Keywords name="Keywords8"></Keywords>
             <Keywords name="Delimiters">00@title 00@dev 00@param 00@return 00@author 01 02((EOL)) 02((EOL)) 02((EOL)) 02((EOL)) 02((EOL)) 03&quot; 04 05&quot; 06( 07 08) 09[ 10 11] 12{ 13 14} 15 16 17 18 19 20 21 22 23</Keywords>
         </KeywordLists>

--- a/Solidity.xml
+++ b/Solidity.xml
@@ -30,7 +30,7 @@
             <Keywords name="Keywords4">bool int int8 int16 int32 int64 int128 int256 uint uint8 uint16 uint32 uint64 uint128 uint256 address mapping string struct enum</Keywords>
             <Keywords name="Keywords5">fixed ufixed bytes</Keywords>
             <Keywords name="Keywords6">TODO &quot;TO DO&quot; todo &quot;to do&quot;</Keywords>
-            <Keywords name="Keywords7">Transfer push length gas call delegatecall callcode send transfer balance msg ecrecover keccak256 ripemd160 sha256 sha3 mulmod addmod encodePacked encode encodeWithSelector encodeWithSignature tx block now assert require revert blockhash coinbase difficulty gaslimit number timestamp gasleft data gas sender sig value selfdistruct suicide abi</Keywords>
+            <Keywords name="Keywords7">Transfer push length gas call delegatecall callcode send transfer balance msg ecrecover keccak256 ripemd160 sha256 sha3 mulmod addmod encodePacked encode encodeWithSelector encodeWithSignature tx block now assert require revert blockhash coinbase difficulty gaslimit number timestamp gasleft data gas sender sig value selfdistruct suicide abi origin</Keywords>
             <Keywords name="Keywords8"></Keywords>
             <Keywords name="Delimiters">00@title 00@dev 00@param 00@return 00@author 01 02((EOL)) 02((EOL)) 02((EOL)) 02((EOL)) 02((EOL)) 03&quot; 04 05&quot; 06( 07 08) 09[ 10 11] 12{ 13 14} 15 16 17 18 19 20 21 22 23</Keywords>
         </KeywordLists>


### PR DESCRIPTION
It allows highlighting the whole `tx.origin` and not only `tx` keyword !
Example :
![image](https://user-images.githubusercontent.com/60298855/115393940-89b5b580-a1e2-11eb-820f-6b979522a1f9.png)